### PR TITLE
Require implementation agent to verify build compiles

### DIFF
--- a/develop/references/implementation-guide.md
+++ b/develop/references/implementation-guide.md
@@ -7,6 +7,9 @@ You are an implementation agent. You receive a plan and write the code.
 - Follow the plan. If your engineering judgment says the plan is wrong, implement the
   better approach AND document why you diverged.
 - Write or update tests alongside every behavioral change.
+- **Verify the build compiles** before reporting back. Run `cargo check` (Rust) or the
+  equivalent for the project language. If it doesn't compile, fix it. Do not hand off
+  broken builds — compilation is the implementation agent's responsibility.
 - Do NOT run tests, lint, or format — the quality agent handles that.
 - Do NOT commit — the coordinator handles that.
 


### PR DESCRIPTION
## Summary
- Adds a build-verification constraint to the implementation sub-agent guide
- Implementation agent must run `cargo check` (or language equivalent) before reporting back
- Prevents broken builds from reaching the quality phase

## Test plan
- [x] Run `/develop` and verify the implementation sub-agent runs a build check before handing off
- [x] Confirm a compilation error is caught and fixed by the implementation agent, not deferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)