### PR TITLE
Rename publish → edit-skill with edit-then-publish workflow

### DIFF
--- a/edit-skill/SKILL.md
+++ b/edit-skill/SKILL.md
@@ -1,15 +1,25 @@
 ---
-name: publish
-description: "Publish skill changes — detects edits, creates a feature branch, commits, pushes, and opens a PR against main. Invoke after modifying any skill files."
+name: edit-skill
+description: "Edit and publish skill changes. Takes a description of what to change as arguments, makes the edits, then handles the git workflow (branch, commit, push, PR). Use when you need to modify an existing skill or create a new one."
 ---
 
-# /publish — Publish Skill Changes
+# /edit-skill — Edit and Publish Skills
 
-Handles the git workflow for skill edits so any session can modify skills and land them
-properly without manual git choreography.
+Modify skills based on a description, then handle the git workflow to land the changes.
 
 Read the `required_environment_variables` Serena global memory if you haven't already this
 session, and use those identities for all git/gh operations throughout.
+
+## Argument handling
+
+`$ARGUMENTS` describes what to change. Examples:
+- `develop: add a Phase 6 for documentation generation`
+- `code-review: increase the large diff threshold to 800 lines`
+- `create a new skill called "tdd" that runs red-green-refactor cycles`
+- `briefing: add a section for checking open draft PRs`
+
+If `$ARGUMENTS` is empty, check for uncommitted changes in the skills repo and
+publish those (legacy publish-only mode).
 
 ## Prerequisites
 
@@ -17,7 +27,22 @@ This skill operates on the skills repo at `~/.claude/skills`. It assumes:
 - The repo is initialized and has `origin` pointing to GitHub
 - Branch protection on `main` requires PRs (no direct push)
 
-## Phase 1: Detect and analyze changes
+## Phase 1: Understand and plan
+
+1. Parse `$ARGUMENTS` to understand the desired change
+2. Read the target skill's SKILL.md and any relevant references
+3. If creating a new skill, identify the right directory and structure
+4. Summarize what you'll change before making edits
+
+## Phase 2: Make the edits
+
+1. Edit the skill files to implement the requested changes
+2. For existing skills: use the Edit tool for targeted changes
+3. For new skills: create the directory structure and SKILL.md
+4. For reference files: update or create as needed
+5. Review your edits — read the modified files back to verify correctness
+
+## Phase 3: Detect and analyze all changes
 
 1. `git status` in `~/.claude/skills`
 2. If the working tree is clean — report "Nothing to publish" and stop
@@ -26,7 +51,7 @@ This skill operates on the skills repo at `~/.claude/skills`. It assumes:
 
 Review every changed file and understand what each edit does.
 
-## Phase 2: Group changes into logical units
+## Phase 4: Group changes into logical units
 
 Analyze the changes and decide how to split them:
 
@@ -45,42 +70,41 @@ Guiding principles:
 Summarize the grouping before proceeding (e.g. "I see two independent changes: X and Y.
 I'll create separate PRs for each.").
 
-## Phase 3: For each logical group, branch → commit → push → PR
+## Phase 5: For each logical group, branch → commit → push → PR
 
 Process each group sequentially. For each one:
 
-### 3a. Ensure on the right branch
+### 5a. Ensure on the right branch
 - Start from `main` (pull latest first)
 - Create a new branch named after the change (e.g. `skill/develop-add-phase`,
-  `skill/publish-new-skill`). Use `skill/` prefix.
+  `skill/edit-skill-rename`). Use `skill/` prefix.
 - If already on a `skill/*` branch that matches this group: stay on it
 
-### 3b. Commit
+### 5b. Commit
 - Stage only the files belonging to this logical group
 - Write a descriptive commit message summarizing the change
 - Multiple commits within a group are fine if they represent distinct steps
-  (e.g. "add new skill" then "wire up reference doc")
 
-### 3c. Push
+### 5c. Push
 - Push to origin with `-u`
 
-### 3d. Open or update PR
+### 5d. Open or update PR
 - If no PR exists for this branch: create one via `gh pr create`
   - Title: concise description of the skill change
   - Body: summary of what changed and why, with the standard footer
 - If a PR already exists: update the description if new commits were added,
   or just report the PR URL
 
-### 3e. Return to main
+### 5e. Return to main
 - `git checkout main` before starting the next group
 
-## Phase 4: Wait for merge
+## Phase 6: Wait for merge
 
 After all PRs are created, report the PR URLs and **wait for the user** to confirm
 each PR is merged. Do not switch back to main or pull until the user says the PR(s)
 are merged.
 
-## Phase 5: Return to main
+## Phase 7: Return to main
 
 Once the user confirms the PR(s) are merged:
 1. `git checkout main && git pull`
@@ -90,7 +114,7 @@ Once the user confirms the PR(s) are merged:
 
 After creating PRs:
 ```
-## Published skill changes
+## Skill changes published
 
 ### PR 1: <title>
 **Branch**: skill/<name>


### PR DESCRIPTION
## Summary
- Rename `/publish` to `/edit-skill` — the skill now both makes edits and publishes them
- `$ARGUMENTS` describes desired changes; the skill reads the target skill, makes edits, then handles git workflow
- Empty arguments fall back to publish-only mode (backward compatible)

## Changes
- `publish/SKILL.md` → `edit-skill/SKILL.md` (rename + enhancement)
- Added Phase 1 (understand/plan) and Phase 2 (make edits) before the existing publish phases
- Renumbered subsequent phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)