### PR TITLE
Add branch protection and docs verification to develop skill

### DIFF
--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -219,9 +219,12 @@ After all phases pass (review is clean or user accepts remaining P3s):
    `.serena/.gitignore` doesn't exclude — this includes `project.yml` (project config),
    `.gitignore`, and `memories/` (project-scoped knowledge shared across sessions).
    Serena's own `.gitignore` already excludes `cache/` and `project.local.yml`.
-2. Commit with a descriptive message following repo conventions
-3. Push to the feature branch
-4. Use `GIT_CONFIG_GLOBAL=~/.gitconfig.ai` and `GH_CONFIG_DIR=~/.config/gh-butterflysky-ai`
+2. **Rust projects**: run `cargo doc --no-deps` before committing. This verifies that
+   documentation builds cleanly — doc warnings or errors must be fixed before proceeding.
+   The generated output in `target/doc/` is not committed (it's gitignored).
+3. Commit with a descriptive message following repo conventions
+4. Push to the feature branch
+5. Use `GIT_CONFIG_GLOBAL=~/.gitconfig.ai` and `GH_CONFIG_DIR=~/.config/gh-butterflysky-ai`
    for all git/gh operations
 
 ### 5c. Create PR
@@ -230,7 +233,15 @@ After all phases pass (review is clean or user accepts remaining P3s):
 3. Body: summary from 5a, list of ADRs written, link to any tracking issue
 4. If a tracking issue exists, link it in the PR body
 
-### 5d. Tracking
+### 5d. Branch protection
+On the first PR for a new repo, check if main has branch protection rulesets:
+```bash
+gh api repos/{owner}/{repo}/rulesets --jq 'length'
+```
+If `0` (no rulesets), create them per [references/repo-setup.md](references/repo-setup.md).
+This is a one-time setup — skip on subsequent PRs.
+
+### 5e. Tracking
 1. Check if a tracking issue exists in `butterflyskies/tasks` for this work
 2. If not, create one: `gh issue create --repo butterflyskies/tasks --title "<work description>"`
 3. Comment on the tracking issue with the PR link and a brief status update

--- a/develop/references/repo-setup.md
+++ b/develop/references/repo-setup.md
@@ -84,3 +84,44 @@ jobs:
 ```
 
 CI is the safety net — if local hooks were bypassed, CI catches it.
+
+## Docs (GitHub Pages via Actions) — Rust
+
+For Rust projects, publish `cargo doc` output to GitHub Pages on every push to main:
+
+```yaml
+name: Docs
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: pages
+  cancel-in-progress: true
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build docs
+        run: cargo doc --no-deps --document-private-items
+      - name: Add redirect
+        run: echo '<meta http-equiv="refresh" content="0;url=<crate_name>/index.html">' > target/doc/index.html
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+Replace `<crate_name>` with the actual crate name (hyphens become underscores).
+Enable GitHub Pages in repo settings → Pages → Source: GitHub Actions.
+
+The `cargo doc --no-deps` step in Phase 5b of the develop skill verifies docs build
+cleanly before committing — the CI job here handles publishing to Pages.


### PR DESCRIPTION
## Summary
- **Phase 5d (new)**: Automatically check for branch protection rulesets on first PR to a new repo; create them per repo-setup.md if missing
- **Phase 5b**: Verify `cargo doc --no-deps` builds cleanly before committing (Rust projects only). Output is not committed — publishing handled by CI
- **repo-setup.md**: Added GitHub Pages via Actions workflow template for publishing Rust docs on push to main

## Test plan
- [ ] Run `/develop` on a new repo — verify branch protection rulesets are created
- [ ] Run `/develop` on a Rust project — verify `cargo doc` runs before commit
- [ ] Verify docs CI workflow template is correct YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)