### PR TITLE
develop: add pre-flight checklist to implementation guide

### DIFF
--- a/develop/references/implementation-guide.md
+++ b/develop/references/implementation-guide.md
@@ -23,6 +23,53 @@ You are an implementation agent. You receive a plan and write the code.
 3. Write tests in the same file's `#[cfg(test)] mod tests` (Rust) or equivalent
 4. Report what you changed and any plan divergences
 
+## Pre-flight checklist
+
+Before reporting back, run through every item. These are patterns learned from real
+review cycles — each one caused P1 or P2 findings that required fix-and-re-review loops.
+
+1. **Security guard consistency** — New code that does file I/O must use the same
+   guards as existing code paths (path validation, symlink protection, hardened wrappers).
+   *Check:* grep for `assert_within_root`, `write_memory_file`, `O_NOFOLLOW`, or
+   equivalent guards. If existing code uses them, your new code must too. Never use raw
+   `std::fs::write`/`read` when the codebase has hardened alternatives.
+
+2. **Lazy resource acquisition** — Don't acquire a resource (auth token, DB connection,
+   lock) before a check that might make it unnecessary.
+   *Check:* for each resource acquired early in a function, trace all early-return paths
+   below it. Can any early return be reached after the acquisition fails? If so, defer
+   acquisition until after the check.
+
+3. **Error path cleanup** — Stateful operations (git merge, transactions, temp files)
+   must clean up on ALL error paths, not just the happy path.
+   *Check:* for each state-entering call (e.g., `repo.merge()`), trace every `?` and
+   `return Err(...)` between it and the corresponding cleanup call. If any error path
+   skips cleanup, add a guard or an explicit cleanup-on-error block.
+
+4. **Sibling operation consistency** — When adding a guard, validation, or fix to one
+   operation, all sibling operations (CRUD counterparts, parallel handlers) need the
+   same treatment.
+   *Check:* use grep or `find_referencing_symbols` to find all operations that share the
+   same pattern as the one you changed. Verify each one has the same guard.
+
+5. **Input validation at system boundaries** — External inputs (CLI args, MCP tool
+   parameters, data from remotes) must be validated before reaching internal operations.
+   *Check:* for each external input that flows into a path, command, ref, query, or
+   format string, verify it's validated or sanitized first. String interpolation into
+   `refs/heads/{branch}` or `path.join(user_input)` without validation is a red flag.
+
+6. **Credential hygiene** — Never log, display, or include in error messages any value
+   that could contain credentials.
+   *Check:* search for `info!`, `warn!`, `debug!`, `Display`, `Debug` on any value that
+   could hold a URL (may contain `user:pass@`), token, or path to a secrets file. If
+   found, redact before logging.
+
+7. **Domain result propagation** — When a function returns a rich result type (enum with
+   multiple variants), callers must handle all variants meaningfully.
+   *Check:* for each call that returns an enum result, verify the caller inspects the
+   variant. A `NoRemote` / `NotFound` / `Skipped` result that falls through to "proceed
+   as normal" is a logic gap.
+
 ## Sub-agent prompt template
 
 ```


### PR DESCRIPTION
## Summary
- Adds a 7-item pre-flight checklist to `develop/references/implementation-guide.md`
- Derived from recurring P1/P2 findings across review cycles on memory-mcp PRs #2 and #4
- Each item includes a concrete "Check:" prompt telling the implementation agent exactly what to verify

## Checklist items
1. Security guard consistency
2. Lazy resource acquisition
3. Error path cleanup
4. Sibling operation consistency
5. Input validation at system boundaries
6. Credential hygiene
7. Domain result propagation

## Test plan
- [x] Verified the checklist renders correctly in the implementation guide
- [x] Placement is between "How to work" and "Sub-agent prompt template" sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)