### PR TITLE
Declare MIT OR Apache-2.0 dual-license grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# claude-skills
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.


### PR DESCRIPTION
## Summary

- Adds README.md with dual-license grant declaration (MIT OR Apache-2.0)

## Test plan

- [x] Verify README.md contains correct license section with links to both LICENSE-APACHE and LICENSE-MIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)