### PR TITLE
refactor: migrate memory references from Serena to memory-mcp

### DIFF
--- a/briefing/SKILL.md
+++ b/briefing/SKILL.md
@@ -8,8 +8,8 @@ description: "When requested: session-start situational awareness — notificati
 Scan what's happened since last session and present a concise summary. This skill is
 **read-only** — it never modifies anything (except syncing notification state via gh-notify).
 
-Read the `global/required_environment_variables` Serena global memory if you haven't already this
-session, and use those identities for all gh operations throughout.
+Use memory-mcp's `read` tool to load the `required-environment-variables` memory (scope: global)
+if you haven't already this session, and use those identities for all gh operations throughout.
 
 ## Argument handling
 
@@ -79,7 +79,8 @@ gh api 'repos/butterflyskies/tasks/milestones?state=open'
 
 ## Phase 4: Follow-ups due
 
-Read the `global/periodic_followups` Serena global memory. For each active item:
+Use memory-mcp's `recall` tool to search for periodic follow-ups. If a `periodic-followups`
+memory exists (scope: global), read it. For each active item:
 
 1. Parse `Last checked` date and `Frequency`
 2. Calculate next due date:

--- a/check-in/SKILL.md
+++ b/check-in/SKILL.md
@@ -5,11 +5,11 @@ description: "When requested: execute periodic follow-up checks and update track
 
 # /check-in — Execute Periodic Follow-ups
 
-Run the actual checks for items in the `periodic_followups` global memory, report findings,
-and update `Last checked` dates.
+Run the actual checks for items in the `periodic-followups` memory (scope: global), report
+findings, and update `Last checked` dates.
 
-Read the `required_environment_variables` Serena global memory if you haven't already this
-session, and use those identities for all gh operations throughout.
+Use memory-mcp's `read` tool to load the `required-environment-variables` memory (scope: global)
+if you haven't already this session, and use those identities for all gh operations throughout.
 
 ## Argument handling
 
@@ -24,7 +24,7 @@ session, and use those identities for all gh operations throughout.
 
 ## Phase 1: Identify items to check
 
-1. Read the `periodic_followups` global Serena memory
+1. Use memory-mcp's `read` tool to load the `periodic-followups` memory (scope: global)
 2. Parse each active item's `Last checked` date and `Frequency`
 3. Calculate due dates:
    - weekly = last checked + 7 days
@@ -50,17 +50,8 @@ Collect command output and interpret results:
 For each checked item:
 
 1. **Report findings** — summarize what changed (or didn't) since last check
-2. **Update `Last checked`** — use `edit_memory` on the `periodic_followups` global memory
-   to set today's date:
-   ```
-   edit_memory(
-     memory_file_name="periodic_followups",
-     scope="global",
-     mode="regex",
-     needle=r"(### <N>\. <Title>.*?Last checked:\s*)\d{4}-\d{2}-\d{2}",
-     repl=r"\g<1>YYYY-MM-DD"   # today's date
-   )
-   ```
+2. **Update `Last checked`** — use memory-mcp's `edit` tool on the `periodic-followups`
+   memory (scope: global) to update the date for the checked item.
 3. **If "Done when" is met** — ask the user before moving the item to the Completed Items
    section. Don't move automatically.
 

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -8,9 +8,10 @@ description: "Systematic code review with sub-agent analysis. Works on PRs, bran
 Perform a structured, multi-phase code review. This skill produces actionable findings
 with severity, location, and concrete fixes — not style nits or praise.
 
-Read the `global/code-review-patterns` Serena memory before starting. It contains
-learned patterns from previous reviews that should inform what you look for. If the
-memory doesn't exist yet, proceed without it — findings from this review will seed it.
+Use memory-mcp's `read` tool to load the `code-review-patterns` memory (scope: global)
+before starting. It contains learned patterns from previous reviews that should inform
+what you look for. If the memory doesn't exist yet, proceed without it — findings from
+this review will seed it.
 
 ## Argument handling
 
@@ -30,8 +31,9 @@ memory doesn't exist yet, proceed without it — findings from this review will 
 Before reviewing code, build understanding. This phase is **silent** — no output to user.
 
 1. **Identify the diff** — resolve `$ARGUMENTS` to a concrete set of changed files and hunks
-2. **Read project conventions** — check for `.claude/CLAUDE.md`, Serena project memories
-   (`style_and_conventions`, `project_overview`), and any linter/formatter configs
+2. **Read project conventions** — check for `.claude/CLAUDE.md`, memory-mcp project memories
+   (use `list` filtered by project scope, look for `project-overview`, conventions), and
+   any linter/formatter configs
 3. **Understand architecture** — for non-trivial changes, use Serena's `get_symbols_overview`
    on affected files to understand the surrounding code structure. Read symbol bodies only
    when needed to understand how changed code fits into the system.
@@ -213,7 +215,7 @@ Each sub-agent receives:
 2. Project conventions (from Phase 1)
 3. Symbol overview of affected files
 4. Caller information for changed function signatures
-5. Contents of `global/code-review-patterns` memory (learned patterns)
+5. Contents of `code-review-patterns` memory from memory-mcp (learned patterns)
 6. **Previously dismissed findings** (for multi-round reviews only — see Phase 3)
 
 Use Serena tools within sub-agents for any additional code exploration needed.
@@ -341,7 +343,7 @@ Always tell the user where the review was posted (PR URL, issue URL, or "display
 ## Phase 6: Learn (optional)
 
 If the review produced P1 or P2 findings that reveal a **pattern** (not just a one-off bug),
-update the `global/code-review-patterns` Serena memory:
+update the `code-review-patterns` memory in memory-mcp (scope: global):
 
 - New pattern: what to look for, why it matters, example from this review
 - Refinement: if an existing pattern helped catch something, note the confirmation
@@ -354,8 +356,8 @@ speculative patterns from unconfirmed findings.
 
 ## Configuration
 
-The skill respects project-level overrides. If a project's Serena memories contain a
-`code_review_config` memory, read it and apply:
+The skill respects project-level overrides. If a project's memory-mcp memories contain a
+`code-review-config` memory (check with `list` filtered by project scope), read it and apply:
 
 - **skip_categories**: list of categories to suppress (e.g., `["dead_code"]`)
 - **extra_patterns**: additional domain-specific patterns to check

--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -8,9 +8,9 @@ description: "End-to-end development workflow with sub-agent specialization. Use
 Implement changes using specialized sub-agents, each with a dedicated context window.
 The coordinator (you) stays lean — orchestrate, don't accumulate.
 
-Read `global/required_environment_variables` and `global/rust_code_standards` Serena memories
-if not already loaded this session. Check for project-scoped `style_and_conventions` and
-`project_overview` memories — pass their contents to sub-agents as context.
+Use memory-mcp to load `required-environment-variables` and `rust-code-standards` memories
+(scope: global) if not already loaded this session. Check for project-scoped memories (use
+`list` filtered by project scope) — pass their contents to sub-agents as context.
 
 ## Argument handling
 
@@ -57,7 +57,7 @@ implementation approach. Do NOT write code — produce a plan.
 Task: <task description>
 Project language: <language>
 Build command: <from CLAUDE.md or Cargo.toml etc.>
-Project conventions: <from Serena memories if available>
+Project conventions: <from memory-mcp project memories if available>
 
 Use Serena's symbolic tools to explore the codebase efficiently:
 - get_symbols_overview for file structure

--- a/develop/references/implementation-guide.md
+++ b/develop/references/implementation-guide.md
@@ -80,7 +80,7 @@ Plan:
 
 Language: <detected language>
 Conventions: <from references/<language>.md>
-Project conventions: <from Serena memories if available>
+Project conventions: <from memory-mcp project memories if available>
 
 Files to modify: <list from plan>
 

--- a/develop/references/rust.md
+++ b/develop/references/rust.md
@@ -1,7 +1,7 @@
 # Rust Development Standards
 
-Standards passed to sub-agents working on Rust projects. Source: `global/rust_code_standards`
-Serena memory + user workflow preferences.
+Standards passed to sub-agents working on Rust projects. Source: `rust-code-standards`
+memory-mcp memory (scope: global) + user workflow preferences.
 
 ## Anti-patterns to avoid
 

--- a/edit-skill/SKILL.md
+++ b/edit-skill/SKILL.md
@@ -7,8 +7,8 @@ description: "Edit and publish skill changes. Takes a description of what to cha
 
 Modify skills based on a description, then handle the git workflow to land the changes.
 
-Read the `required_environment_variables` Serena global memory if you haven't already this
-session, and use those identities for all git/gh operations throughout.
+Use memory-mcp's `read` tool to load the `required-environment-variables` memory (scope: global)
+if you haven't already this session, and use those identities for all git/gh operations throughout.
 
 ## Argument handling
 

--- a/land/SKILL.md
+++ b/land/SKILL.md
@@ -8,11 +8,11 @@ disable-model-invocation: false
 
 Run this when wrapping up a work session. Work through each phase in order.
 
-Read the `required_environment_variables` Serena memory if you haven't already this session,
-and use those identities for all git/gh operations throughout.
+Use memory-mcp's `recall` or `read` tool to load the `required-environment-variables` memory
+if you haven't already this session, and use those identities for all git/gh operations.
 
-Reference the `infrastructure_overview` memory for GitHub org conventions, project tracker
-locations, and issue routing rules.
+Use `recall` to find the `infrastructure-overview` memory for GitHub org conventions, project
+tracker locations, and issue routing rules.
 
 ## Idempotency
 
@@ -26,12 +26,12 @@ should check whether there's actually something new to do before acting:
 
 ## Phase 1: Capture learnings
 
-Review what happened this session and update relevant Serena memories:
+Review what happened this session and update relevant memories via memory-mcp:
 - New project knowledge, architecture changes, resolved design questions
 - Workflow preferences or patterns that emerged
 - Corrections to stale information (test counts, binary sizes, branch status, etc.)
 
-Use Serena's memory tools (`edit_memory` / `write_memory`) for all updates.
+Use memory-mcp tools (`edit` / `remember`) for all updates. Run `sync` after.
 
 ## Phase 2: Git housekeeping
 
@@ -110,8 +110,9 @@ figured out. Not a dry changelog; a record of progress that's satisfying to read
 
 ## Phase 8: Session handoff
 
-Write a **project-scoped** handoff memory (e.g. `session_handoff` in the active project)
-only when there is genuinely complex in-flight context that would take time to re-derive.
+Write a **project-scoped** handoff memory (e.g. `session-handoff` with `scope: "project:<name>"`)
+via memory-mcp's `remember` tool, only when there is genuinely complex in-flight context that
+would take time to re-derive.
 
 When writing one:
 - What was being worked on and where it left off


### PR DESCRIPTION
## Summary
- All 8 skill files updated to reference memory-mcp tools instead of Serena memory tools
- Serena code intelligence references (find_symbol, get_symbols_overview, etc.) preserved
- Corresponds to Serena config change: memory tools excluded via `excluded_tools` in `~/.serena/serena_config.yml`

## Skills updated
- land, briefing, check-in, code-review, develop, edit-skill
- develop/references/rust.md, develop/references/implementation-guide.md

## Context
memory-mcp is now deployed at `memory-mcp.svc.echoes` and wired into Claude Code as the `memory` MCP server. All Serena memories have been migrated. This PR completes Phase 6 of the deployment workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)