### PR TITLE
feat: add resource lifecycle checks to review and develop skills

### DIFF
--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -80,6 +80,9 @@ Review the following changes for:
 - For each pattern match on input: trace all callers — what inputs reach this code
   that DON'T match any handled pattern?
 - "Inputs always look like X" is a red flag — verify by tracing actual data flow
+- For each resource created (sessions, connections, handles, caches, temp files):
+  what cleans it up? Timeout, eviction, explicit close, Drop impl? If nothing
+  cleans it up, that's a finding.
 
 **Data integrity**
 - Mutations that could corrupt or lose data (wrong UPDATE scope, missing WHERE clause)
@@ -169,6 +172,9 @@ For each change that touches trust boundaries, data flows, or auth:
 - Repudiation: can actions occur without accountability/logging?
 - Information disclosure: can sensitive data leak via logs, errors, side channels?
 - Denial of service: can an attacker exhaust resources (CPU, memory, connections)?
+  Specifically: stateful services that accept external connections — is there a
+  session/connection limit and idle timeout? Unbounded accumulation from external
+  triggers is a resource exhaustion vector.
 - Elevation of privilege: can a user gain access beyond their authorization?
 
 Also check for concrete injection vectors:

--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -46,8 +46,10 @@ Dispatch a **planning sub-agent** (model: opus) to:
    `find_symbol` with `include_body=true` only for symbols that need modification
 3. Identify all files and symbols that need to change
 4. For each changed function/method signature, use `find_referencing_symbols` to find callers
-5. Propose an approach: what changes, in what order, and why
-6. Flag risks, ambiguities, or decisions that need user input
+5. For stateful subsystems: identify resource lifecycle (creation → cleanup → limits).
+   External connections/sessions require a timeout and max-count strategy in the plan.
+6. Propose an approach: what changes, in what order, and why
+7. Flag risks, ambiguities, or decisions that need user input
 
 **Sub-agent prompt template:**
 ```

--- a/develop/references/implementation-guide.md
+++ b/develop/references/implementation-guide.md
@@ -70,6 +70,13 @@ review cycles — each one caused P1 or P2 findings that required fix-and-re-rev
    variant. A `NoRemote` / `NotFound` / `Skipped` result that falls through to "proceed
    as normal" is a logic gap.
 
+8. **Resource lifecycle** — Every created resource (session, connection, handle, temp
+   file, cache entry) must have a corresponding cleanup path. If the resource is
+   externally triggered (e.g., client connections creating sessions), require a timeout
+   and/or cap.
+   *Check:* for each long-lived resource created, trace what removes it. If nothing does,
+   that's a memory leak. If it's externally triggered with no bound, that's a DoS vector.
+
 ## Sub-agent prompt template
 
 ```


### PR DESCRIPTION
## Summary
Encode resource lifecycle awareness into the code review and development skills so that session/connection/handle cleanup is never overlooked again.

## Changes
- **code-review sub-agent A**: Added resource cleanup check to Completeness gaps ("for each resource created... what cleans it up?")
- **code-review sub-agent C**: Expanded DoS check under STRIDE to specifically call out unbounded session/connection accumulation
- **develop Phase 1 planning**: Added step 5 — identify resource lifecycle for stateful subsystems
- **implementation-guide pre-flight checklist**: Added item #8 — Resource lifecycle

## Context
Learned from memory-mcp #80 — MCP sessions accumulated indefinitely because `LocalSessionManager::default()` set `keep_alive: None`. The planning phase focused on what the system does, not what it creates and who cleans it up. The code review didn't catch it because `..Default::default()` on a resource manager looked innocuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)