### PR TITLE
feat: add dead-allocation check to code-review sub-agent B

### DIFF
--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -114,6 +114,8 @@ Review the following changes for:
 - Code that the change made unreachable or unnecessary
 - Duplicated logic that should be consolidated
 - Imports, variables, enum variants, or parameters that are no longer used
+- For `Option`-guarded features: does disabling the feature leave allocated-but-unused
+  fields? If so, group the feature's state into a sub-struct and wrap in `Option`.
 
 **Testing gaps**
 - Changed behavior that has no corresponding test update


### PR DESCRIPTION
## Summary
Add a check to Sub-agent B (Design & Maintainability) for `Option`-guarded features that leave allocated-but-unused fields when disabled.

## Context
Learned from memory-mcp #82 round 2: `rate_tracker: Mutex<VecDeque<Instant>>` was allocated on every `BoundedSessionManager` even when rate limiting was disabled. Refactored to `Option<RateLimiter>` so the allocation only exists when the feature is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)