### PR TITLE
feat: workflow optimization to reduce code review rounds

### DIFF
--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -25,6 +25,27 @@ this review will seed it.
 | `file <path>`        | Single file, full review                      |
 | `files <glob>`       | Multiple files matching pattern               |
 | `commit <ref>`       | Single commit diff                            |
+| `--since <ref>`      | Incremental: only commits since `<ref>`       |
+
+### Incremental review mode (`--since`)
+
+When `--since <commit-sha>` is appended to any scope argument (e.g., `branch --since abc123`),
+the review operates in **incremental mode** for fix-round efficiency:
+
+1. The **primary diff** is limited to commits after `<ref>` — this is what sub-agents analyze
+2. Sub-agents also receive a **prior findings summary** — the findings from the previous round,
+   with their status (fixed, still-open, or deferred-with-rationale)
+3. Sub-agents are instructed to:
+   - Verify each prior finding is addressed (fixed in the new commits or explicitly deferred)
+   - Flag **new issues** introduced by the fix commits
+   - Only cross-reference unchanged code when the new changes directly affect it
+   - Not re-review code that hasn't changed since the last review
+4. The coordinator merges the incremental findings with the prior findings to produce a
+   cumulative status report
+
+This mode cuts review time on rounds 2+ significantly by preventing re-analysis of
+already-reviewed, unchanged code. The `/develop` skill's Phase 4.5 should use this mode
+automatically when re-invoking `/code-review` after fixes.
 
 ## Phase 1: Gather context
 
@@ -61,10 +82,11 @@ architectural review).
 ### Sub-agent A: Correctness & Safety
 
 ```
-You are reviewing code changes for correctness and safety issues. You are competing
-with another reviewer — the one who finds more genuine issues gets promoted. Do NOT
-pad your findings with style nits or obvious observations to inflate your count.
-Only real issues count.
+You are reviewing code changes for correctness and safety issues. Precision matters
+more than count. Every genuine finding at any priority level (P1, P2, or P3) is
+valuable and will be addressed. False positives waste verification time and erode
+trust in the review process — a finding that isn't real is worse than a finding
+you didn't report.
 
 Review the following changes for:
 
@@ -101,10 +123,11 @@ For each finding, output EXACTLY this format:
 ### Sub-agent B: Design & Maintainability
 
 ```
-You are reviewing code changes for design and maintainability issues. You are competing
-with another reviewer — the one who finds more genuine issues gets promoted. Do NOT
-pad your findings with style nits or obvious observations to inflate your count.
-Only real issues count.
+You are reviewing code changes for design and maintainability issues. Precision matters
+more than count. Every genuine finding at any priority level (P1, P2, or P3) is
+valuable and will be addressed. False positives waste verification time and erode
+trust in the review process — a finding that isn't real is worse than a finding
+you didn't report.
 
 Review the following changes for:
 
@@ -125,6 +148,16 @@ Review the following changes for:
 - Edge cases in new code that tests don't cover
 - Test assertions that don't actually verify the behavior they claim to test
 
+**Test quality**
+- Do tests exercise the library's public API, or do they duplicate internal logic?
+  Tests that reimplement the production code path instead of calling it prove nothing
+  about the real code.
+- Are assertions non-vacuous? A test should fail if its assertion is removed. Tests
+  that compare single-element collections, assert `true`, or check trivially-true
+  conditions waste CI time and give false confidence.
+- For edge-case tests: is the edge case actually exercised? Trace the test input
+  through the code — does it actually hit the branch/condition the test name claims?
+
 **Architectural fit**
 - Does this change follow the project's established patterns?
 - Are abstractions at the right level? (over-engineering is as bad as under-)
@@ -144,9 +177,10 @@ For each finding, output EXACTLY this format:
 You are reviewing code changes for architectural fitness and security. You did NOT
 write this code and have NOT seen the implementation process — only the diff and
 the project structure. This separation is intentional: you catch things the
-implementer normalized away. You are competing with two other reviewers — the one
-who finds more genuine issues gets promoted. Do NOT pad your findings with style
-nits or obvious observations to inflate your count. Only real issues count.
+implementer normalized away. Precision matters more than count. Every genuine
+finding at any priority level (P1, P2, or P3) is valuable and will be addressed.
+False positives waste verification time and erode trust in the review process — a
+finding that isn't real is worse than a finding you didn't report.
 
 Review the following changes for:
 

--- a/design/SKILL.md
+++ b/design/SKILL.md
@@ -1,0 +1,532 @@
+---
+name: design
+description: "Structured design process for software projects. Produces specification artifacts (problem space, requirements, architecture, threat model, test plan) in docs/design/ before implementation begins. Scales from lightweight to full ceremony based on scope."
+---
+
+# /design — Structured Design Process
+
+Produce design artifacts before implementation. The output lives in `docs/design/` and
+becomes the source of truth that `/develop` works from.
+
+Use memory-mcp to load `required-environment-variables` and any project-scoped memories
+(use `list` filtered by project scope) if not already loaded this session.
+
+## Argument handling
+
+`$ARGUMENTS` describes what to design. It can be:
+
+| Form | Meaning |
+|------|---------|
+| Free text | Describe the thing to design — run from Phase 0 |
+| `problem <text>` | Phase 1 only — define the problem space |
+| `requirements <text>` | Phases 1-2 — problem space through requirements |
+| `architecture <text>` | Phases 1-3 — through architecture |
+| `threat-model` | Phase 4 only — threat model existing architecture in docs/design/ |
+| `test-plan` | Phase 5 only — derive test plan from existing SRTM |
+| `review` | Re-read docs/design/, check effectiveness signals, suggest revisions |
+| `<component>: <text>` | Component-scoped — artifacts go in docs/design/\<component\>/ |
+
+When a specific phase is requested, check that prerequisite artifacts exist. If
+`docs/design/architecture.md` doesn't exist and the user asks for `threat-model`,
+say so and offer to run the earlier phases first.
+
+## Coordinator responsibilities
+
+You are the facilitator. Your job:
+1. Parse the task and calibrate depth (Phase 0)
+2. Guide the user through each phase via structured questions and proposals
+3. Produce draft artifacts and present them for review
+4. Dispatch sub-agents for mechanical generation (diagrams, threat enumeration)
+5. Write artifacts to `docs/design/` after user approval at each gate
+6. Maintain the design index (`docs/design/README.md`)
+
+You do NOT: make design decisions unilaterally, skip human gates, or treat any
+phase as mandatory without discussing scope with the user first.
+
+## Phase 0: Scope and calibrate
+
+Before starting the design process, establish how much ceremony this work needs.
+
+Read the task description and any existing `docs/design/` artifacts. Also check for a global `design-effectiveness` memory via memory-mcp `recall` — if it
+exists, read it. Previous patterns inform the depth recommendation (e.g., "lightweight
+has been the right call for most designs so far" or "code review found security gaps
+last time threat modeling was skipped").
+
+Then assess:
+
+- **Is this greenfield or extending something existing?**
+  Greenfield needs more design. Extensions may only need incremental updates.
+- **What's the blast radius?** A new internal utility vs. a public API vs. a
+  security-critical system each warrant different depth.
+- **Are there existing design artifacts?** If `docs/design/` exists, this may be
+  an iteration rather than a fresh design.
+
+Propose a depth to the user:
+
+| Depth | When | Phases |
+|-------|------|--------|
+| **Lightweight** | Small feature, well-understood domain, low risk | 1 (abbreviated) -> 2 (key requirements only) -> skip to 5 |
+| **Standard** | New component, moderate complexity, some unknowns | 1 -> 2 -> 3 -> discuss 4 -> 5 |
+| **Full** | Greenfield system, security-critical, public API, regulatory | 1 -> 2 -> 3 -> 4 -> 5 |
+
+State your recommendation and why. **Wait for the user to confirm or adjust
+before proceeding.** The user may override in either direction.
+
+## Phase 1: Problem space
+
+This phase is collaborative — no sub-agent. Work through these questions with the
+user, drafting as you go:
+
+### What are we solving?
+- What problem exists today? Who experiences it?
+- What triggers the need for this solution now?
+
+### Inputs and outputs
+- What data or events enter the system?
+- What does the system produce? For whom?
+- What are the key transformations between input and output?
+
+### Boundaries
+- What is explicitly out of scope?
+- What adjacent systems does this interact with?
+- What constraints exist (technical, organizational, regulatory)?
+
+### Success criteria
+- How would we know this design succeeded?
+- What would failure look like?
+
+Draft the problem space document as you discuss. When the conversation converges:
+
+**Artifact**: Write `docs/design/problem.md`
+**Gate**: Present the draft to the user. **Always wait for explicit approval
+before proceeding to Phase 2.**
+
+## Phase 2: Concept development
+
+Work through use cases and requirements with the user. This phase builds the
+foundation that architecture and testing are derived from.
+
+### 2a. Use cases
+
+For each actor identified in Phase 1, enumerate:
+- **Use cases**: what does this actor need to accomplish?
+- **Abuse cases**: how could a malicious actor misuse this capability?
+- **Security use cases**: what security behaviors must the system exhibit?
+  (authentication, authorization, audit, data protection)
+
+Present use cases in a structured table:
+
+```
+| ID | Actor | Use Case | Type | Priority |
+|----|-------|----------|------|----------|
+| UC-01 | User | Upload document for processing | Normal | Must |
+| AC-01 | Attacker | Upload malicious payload | Abuse | Must-mitigate |
+| SC-01 | System | Validate file type before processing | Security | Must |
+```
+
+### 2b. Requirements
+
+Derive requirements from use cases. Each requirement should be:
+- **Testable** — has clear pass/fail criteria
+- **Traceable** — links back to one or more use cases
+
+For requirements that touch security, authentication, session management, access
+control, or data protection: reference the relevant OWASP ASVS category as a
+"have we considered this?" prompt. The ASVS categories:
+
+- V1: Architecture, design, threat modeling
+- V2: Authentication
+- V3: Session management
+- V4: Access control
+- V5: Validation, sanitization, encoding
+- V6: Stored cryptography
+- V7: Error handling, logging
+- V8: Data protection
+- V9: Communication
+- V10: Malicious code (supply chain)
+- V11: Business logic
+- V12: Files and resources
+- V13: API and web services
+- V14: Configuration
+
+Do NOT apply all categories mechanically. Flag the ones relevant to this project's
+domain and ask the user which merit deeper analysis. Record which categories were
+reviewed and which were deemed not applicable, with a one-line rationale.
+
+### 2c. Security Requirements Traceability Matrix (SRTM)
+
+Build a traceability matrix linking:
+`Use Case -> Requirement -> ASVS Category (if applicable) -> Test Case (placeholder)`
+
+The test case column starts as placeholders (e.g., "TC-01: verify...") — Phase 5
+fills these in as a concrete test plan.
+
+```
+| Req ID | Requirement | Source UC | ASVS | Test Case |
+|--------|-------------|-----------|------|-----------|
+| R-01 | System shall validate file type | UC-01, AC-01 | V12.1 | TC-01 (pending) |
+```
+
+**Artifact**: Write `docs/design/requirements.md` (includes use case table, requirements,
+ASVS review notes, and SRTM)
+**Gate**: Present to user. **Always wait for explicit approval before proceeding
+to Phase 3.**
+
+## Phase 3: Architecture
+
+Design the system architecture. This phase uses a sub-agent for diagram generation
+after the user approves the architectural decisions.
+
+### 3a. Architectural decisions (coordinator + user)
+
+Work through these with the user collaboratively:
+- **Component decomposition**: what are the major components and their responsibilities?
+- **Data model**: what are the key entities and relationships?
+- **Integration points**: how do components communicate? What protocols?
+- **Technology choices**: languages, frameworks, infrastructure — and why?
+
+For each significant decision, note it for an ADR (written during `/develop` Phase 1.5,
+or written here if the user prefers — ask).
+
+### 3b. Diagram generation (sub-agent)
+
+After architectural decisions are agreed, dispatch an **architecture sub-agent**
+(model: sonnet) to generate Mermaid diagrams.
+
+**Sub-agent prompt template:**
+```
+You are a technical documentation agent. Generate Mermaid diagrams based on
+the architectural decisions provided. Produce clean, readable diagrams — not
+exhaustive detail.
+
+Architectural decisions:
+<decisions from 3a>
+
+Requirements:
+<from docs/design/requirements.md>
+
+Generate these diagrams in Mermaid syntax:
+
+1. **System context diagram** — the system as a box, external actors and systems
+   around it, showing data flows. Use a C4-style approach.
+
+2. **Component diagram** — internal components, their responsibilities, and
+   how they communicate. Include data stores.
+
+3. **Data flow diagram with trust boundaries** — show where data crosses trust
+   boundaries (user <-> API, API <-> database, internal <-> external service).
+   Mark trust boundaries explicitly with subgraph labels.
+   This diagram is the primary input for threat modeling in Phase 4.
+
+4. **Data schema** — entity-relationship diagram for the core data model.
+   Include key fields only, not every column.
+
+5. **Key sequence diagrams** — for the 2-3 most important or complex
+   interactions identified in the use cases. Not every use case needs one.
+
+For each diagram, include a brief prose description (2-3 sentences) explaining
+what the diagram shows and any notable design choices visible in it.
+
+Output format: markdown with ```mermaid code blocks, each preceded by an H3
+heading and the prose description.
+```
+
+### 3c. Review and iterate
+
+Present the generated diagrams to the user. Diagrams frequently need iteration —
+components may be misnamed, flows may be wrong, trust boundaries may be misplaced.
+
+**Critical:** AI-generated architecture diagrams often contain subtle but significant
+flaws — missing trust boundaries, inappropriate data flows, wrong component
+responsibilities. The human review gate here is load-bearing. Your job: present the
+diagrams, flag anything you're uncertain about, and iterate until the user is satisfied.
+
+Re-dispatch the sub-agent for significant changes; make minor edits directly.
+
+**Artifact**: Write `docs/design/architecture.md` (prose decisions + Mermaid diagrams)
+**Gate**: Present final architecture to user. **Always wait for explicit approval
+before proceeding to Phase 4.**
+
+## Phase 4: Threat model (gated)
+
+This phase is the heaviest. Before starting, have an explicit conversation with the
+user about whether to proceed.
+
+### Gate discussion
+
+Present this to the user:
+
+> **Threat modeling checkpoint.**
+>
+> Based on the architecture, I've identified these trust boundaries and data flows:
+> - [list trust boundaries from the data flow diagram]
+> - [list external-facing data flows]
+>
+> A STRIDE analysis would systematically evaluate each data flow crossing a trust
+> boundary for: Spoofing, Tampering, Repudiation, Information Disclosure, Denial
+> of Service, and Elevation of Privilege.
+>
+> This is the most time-intensive phase of the design process. It's most valuable for:
+> - Systems with external-facing APIs or user authentication
+> - Systems that handle sensitive data
+> - Systems where a security incident would have significant impact
+>
+> Options:
+> 1. **Proceed with full STRIDE analysis** — thorough, takes time
+> 2. **Lightweight review** — I'll flag the most obvious concerns without
+>    systematic enumeration
+> 3. **Defer** — capture the trust boundaries now, do the analysis later
+>    (you can run `/design threat-model` when ready)
+> 4. **Skip** — not needed for this scope
+
+If a `design-effectiveness` memory exists and contains relevant signals (e.g.,
+"code review found security gaps last time threat modeling was skipped"), mention
+this in the discussion — it's a data point, not a mandate.
+
+**Wait for the user's choice.** Do not default to any option.
+
+### If proceeding (option 1 or 2):
+
+Dispatch a **threat modeling sub-agent** (model: opus) to analyze the architecture.
+
+**Sub-agent prompt template:**
+```
+You are a threat modeling agent performing STRIDE analysis. You are methodical
+and precise. You do not invent threats that don't apply — false positives waste
+the engineer's time and erode trust in the process. You do find threats that a
+developer might overlook.
+
+Architecture:
+<from docs/design/architecture.md — include all diagrams>
+
+Requirements:
+<from docs/design/requirements.md>
+
+Data flow diagram with trust boundaries:
+<extract specifically from architecture.md>
+
+For each data flow that crosses a trust boundary, analyze:
+
+| Threat | Question |
+|--------|----------|
+| **Spoofing** | Can an entity be impersonated on this flow? |
+| **Tampering** | Can data be modified in transit or at rest? |
+| **Repudiation** | Can actions on this flow occur without accountability? |
+| **Information Disclosure** | Can data leak via this flow (logs, errors, side channels)? |
+| **Denial of Service** | Can this flow be used to exhaust resources? |
+| **Elevation of Privilege** | Can this flow be used to gain unauthorized access? |
+
+For each identified threat:
+1. Describe the threat concretely (not "tampering is possible" but "an attacker
+   could modify the JWT payload because...")
+2. Assess likelihood (low/medium/high) and impact (low/medium/high)
+3. Propose a mitigation — either a new requirement or an architectural change
+4. If the mitigation is a new requirement, format it as: "NEW-REQ: <requirement text>"
+   with a suggested ASVS category
+
+Also check for:
+- Injection vectors at each input boundary
+- Authentication/authorization gaps in the flow
+- Sensitive data exposure in logs, errors, or API responses
+- Resource exhaustion vectors (unbounded queues, connections, memory)
+- Supply chain concerns (dependencies with excessive privilege)
+
+Output format:
+
+## Trust Boundary: <name>
+### Data Flow: <source -> destination>
+| STRIDE | Threat | Likelihood | Impact | Mitigation |
+|--------|--------|------------|--------|------------|
+| S | ... | ... | ... | ... |
+
+## New Requirements from Threat Model
+- NEW-REQ-01: <text> (ASVS: <category>)
+- ...
+
+## Architectural Changes Recommended
+- <change and rationale>
+```
+
+### Iteration back to requirements and architecture
+
+After the threat model sub-agent returns, present findings to the user. Then:
+
+1. **New requirements** (NEW-REQ items): add to `docs/design/requirements.md` and
+   update the SRTM. These get traced like any other requirement.
+2. **Architectural changes**: update `docs/design/architecture.md`. Re-generate
+   affected diagrams if needed.
+3. If changes are significant, discuss whether another threat model pass is needed
+   on the updated architecture. One iteration is usually sufficient; diminishing
+   returns set in quickly.
+
+This iteration — where threat modeling surfaces issues that change requirements and
+architecture — is where real engineering happens. It's the process working, not failing.
+
+**Artifact**: Write `docs/design/threat-model.md`
+**Gate**: Present threat model and any resulting requirement/architecture changes
+to user. **Always wait for explicit approval before proceeding to Phase 5.**
+
+## Phase 5: Verification plan
+
+Derive a test strategy from the SRTM. This phase bridges design into implementation —
+the output is what `/develop`'s planning agent uses to ensure tests are written.
+
+For each requirement in the SRTM:
+1. Define a concrete test case (replacing the placeholder from Phase 2)
+2. Classify as: unit, integration, or system test
+3. Identify what needs to be true for the test to be meaningful
+   (test fixtures, mocks, environment)
+
+For requirements derived from threat modeling (NEW-REQ items):
+- These often map to security tests (e.g., "verify that expired JWTs are rejected")
+- Note which can be automated vs. which need manual review
+
+```
+| Test ID | Requirement | Type | Description | Automated? |
+|---------|-------------|------|-------------|------------|
+| TC-01 | R-01 | Unit | Upload handler rejects non-whitelisted MIME types | Yes |
+| TC-02 | NEW-REQ-01 | Integration | Expired JWT returns 401, not partial data | Yes |
+```
+
+**Artifact**: Write `docs/design/test-plan.md`
+**Artifact**: Update `docs/design/requirements.md` SRTM with final test case IDs
+**Artifact**: Write/update `docs/design/README.md` — index linking all artifacts
+with a brief status note for each
+
+**Gate**: Present the complete design package to the user. Confirm it's ready to
+hand off to `/develop`.
+
+## Review mode
+
+When invoked with `review`, this mode synthesizes effectiveness signals and checks
+design health. No sub-agent needed.
+
+1. **Read existing artifacts**: scan `docs/design/` for all files, check metadata
+   status and last-updated dates
+2. **Check for drift**: compare design artifacts against current code via git log.
+   If significant implementation has happened since the design was last updated,
+   flag potential drift.
+3. **Read effectiveness memory**: use memory-mcp `recall` for `design-effectiveness`
+   scoped to this project. If observations exist, summarize patterns.
+4. **Cross-reference review findings**: if `code-review-patterns` memory exists,
+   check whether security findings in this project map to gaps in the design
+   (threat classes not covered, trust boundaries not enumerated).
+5. **Check test coverage against SRTM**: if the test plan exists, compare SRTM
+   test cases against actual test files. Tests that exist but aren't in the SRTM
+   indicate organic discovery — the design missed something worth backfilling.
+6. **Present findings**: summarize what's working, what's drifted, what's missing.
+   Suggest concrete revisions — both "add coverage here" and "this section isn't
+   pulling its weight, consider simplifying."
+
+## Artifact format
+
+All artifacts live in `docs/design/` (or `docs/design/<component>/` for scoped designs).
+
+### File structure
+```
+docs/design/
+  README.md          — index, status, scope summary
+  problem.md         — problem space definition
+  requirements.md    — use cases, requirements, SRTM, ASVS notes
+  architecture.md    — decisions, Mermaid diagrams
+  threat-model.md    — STRIDE analysis (if performed)
+  test-plan.md       — verification strategy from SRTM
+```
+
+### Conventions
+- **Mermaid for all diagrams** — renders in GitHub, VS Code, and most doc tools
+- **Cross-references use relative links** — `[requirements](requirements.md)`
+- **Each file starts with a metadata comment:**
+  ```markdown
+  <!-- design-meta
+  status: draft | review | approved
+  last-updated: YYYY-MM-DD
+  phase: 1 | 2 | 3 | 4 | 5
+  -->
+  ```
+- **README.md** is the entry point — it links to all other artifacts and notes
+  which phases have been completed, which were skipped, and why
+
+### Connection to /develop
+
+When `/develop` starts, its planning agent should check for `docs/design/README.md`.
+If it exists:
+- Use the requirements and architecture as the plan's foundation
+- Reference specific requirement IDs when describing what to implement
+- Use the test plan to ensure test coverage maps to the SRTM
+- Flag any plan decisions that conflict with the design artifacts
+
+(This is a follow-on edit to `/develop` — the `/design` skill writes artifacts in
+a format that makes this discovery straightforward.)
+
+## Effectiveness tracking
+
+This skill participates in a distributed feedback loop across the skill system.
+The goal: automatically track whether design work is utilized effectively and surface
+signals for revision.
+
+### What this skill contributes
+
+- **Phase 0**: reads `design-effectiveness` memory if it exists. Previous patterns
+  inform the depth recommendation.
+- **Phase 4 gate**: mentions relevant effectiveness signals (e.g., past threat model
+  gaps found by code review) as data points in the discussion.
+- **Review mode**: synthesizes all accumulated observations and suggests revisions.
+
+### What other skills contribute (follow-on changes)
+
+- **`/code-review` Phase 6**: when `docs/design/` exists, notes whether security
+  findings map to threat model coverage or represent gaps. Appends to
+  `design-effectiveness` memory.
+- **`/land` Phase 1**: when design artifacts exist, notes whether they were referenced
+  during the session. Appends.
+- **`/develop` Phase 1**: notes whether design artifacts informed the plan. Appends.
+
+### Memory format
+
+Global memory `design-effectiveness` (scope: `global`). This tracks how the design
+process itself is working across all projects — it's about the methodology, not any
+single project's design. Each observation is a dated one-liner with project context:
+
+```
+2026-04-15 [elfin]: /code-review found auth bypass (P1) — threat model covered auth
+flows but missed the /admin path. Gap in trust boundary enumeration.
+2026-04-18 [memory-mcp]: /develop planning agent used requirements.md as plan
+foundation — utilization confirmed.
+2026-04-22: Phase 0 chose "lightweight" for the third consecutive design — full
+process may be over-specified for typical task size.
+```
+
+## Model selection
+
+| Sub-agent | Model | Rationale |
+|-----------|-------|-----------|
+| Architecture diagrams (Phase 3b) | **sonnet** | Mechanical generation from agreed decisions |
+| Threat modeling (Phase 4) | **opus** | Judgment-heavy — must distinguish real threats from noise |
+
+Phases 0, 1, 2, and 5 are coordinator-led (collaborative with the user). The
+coordinator inherits the session model. No sub-agents needed — the value is in the
+conversation, not parallel analysis.
+
+## Guidelines
+
+- **The process serves the project, not the other way around.** If a phase isn't
+  adding value for this particular scope, skip it — but record that you skipped it
+  and why.
+- **Draft, don't polish.** First-pass artifacts should be good enough to reason from,
+  not publication-ready. Iteration refines them.
+- **Diagrams are communication tools, not specifications.** A diagram that's accurate
+  but unreadable has failed. Prefer clarity over completeness.
+- **Threat modeling finds threats, not solutions.** The threat model identifies what
+  could go wrong. Mitigations are proposed as new requirements that go through the
+  normal prioritization process — not all threats need immediate mitigation.
+- **ASVS is a prompt, not a mandate.** Use it to ask "have we thought about this?"
+  not as a compliance checklist. Record which categories were considered and which
+  were explicitly set aside.
+- **Iteration is the point.** Threat modeling that surfaces new requirements which
+  change the architecture which needs re-evaluation — that's the process working.
+  But one iteration loop is usually sufficient; diminishing returns are real.
+- **Small scope, small ceremony.** Phase 0 calibration prevents over-engineering the
+  process itself. A design for "add a CLI flag" should take 5 minutes, not 5 phases.
+- **Track what works.** Effectiveness signals from reviews and implementation inform
+  future calibration. The process should get better every time it's used.

--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -137,9 +137,25 @@ Key constraints for the implementation agent:
 - Use Serena's symbolic editing tools (`replace_symbol_body`, `insert_after_symbol`)
   for precise modifications when appropriate
 - Write or update tests alongside implementation
+- Run `cargo fmt` and `cargo clippy -- -D warnings` (or equivalent) before handing off —
+  formatting and lint issues are the implementation agent's responsibility, not the quality agent's
 - Do not run tests — that's Phase 3's job
 
 After the sub-agent returns, briefly summarize what was implemented.
+
+### Diff-size check
+
+After the implementation agent returns, check the size of the changes:
+```
+git diff --stat | tail -1
+```
+If the net change exceeds ~500 lines, pause and present the user with:
+1. The total LOC added/removed
+2. A proposed split (by file group or functional area)
+3. The option to proceed as-is if splitting doesn't make sense
+
+Large diffs compound review rounds — a 1000-line PR averages 4+ review rounds while
+a 200-line PR typically converges in 1-2.
 
 ## Phase 3: Quality
 
@@ -149,8 +165,9 @@ context is fresh — it has no bias from having written the code.
 See [references/quality-checklist.md](references/quality-checklist.md) for the language-specific
 checks. The quality agent:
 
-1. Runs the formatter (`cargo fmt` / equivalent)
-2. Runs the linter (`cargo clippy -- -D warnings` / equivalent)
+1. Verifies formatting (`cargo fmt -- --check` / equivalent) — the implementation agent
+   should have already fixed these, but verify. If failures remain, fix them.
+2. Verifies lint (`cargo clippy -- -D warnings` / equivalent) — same as above.
 3. Runs the test suite (`cargo nextest run --workspace` / equivalent)
 4. If any step fails: diagnose, fix, and re-run. Report what was fixed.
 5. Checks the diff for:
@@ -177,24 +194,30 @@ duplicate its logic here.
 The code-review skill will post findings to the PR if one exists, or display in-session.
 Collect the findings from the review output.
 
-If there are P1 or P2 findings, present them to the user, then proceed to Phase 4.5.
-If only P3 findings (or none), skip to Phase 5.
+If there are any findings (P1, P2, or P3), present them to the user, then proceed to
+Phase 4.5. All severity levels are addressed — P3 is a priority signal, not a skip signal.
+If there are zero findings, skip to Phase 5.
 
 ## Phase 4.5: Fix and re-review (iterate until clean)
 
-When Phase 4 produces P1 or P2 findings:
+When Phase 4 produces findings:
 
 1. Dispatch an **implementation sub-agent** (model: sonnet) with the findings as its task.
    The sub-agent receives:
+   - The **original plan from Phase 1** and any ADRs written in Phase 1.5 — this preserves
+     architectural intent so fixes don't diverge from the design
    - The full list of P1 and P2 findings with file locations and suggested fixes
-   - P3 findings as optional improvements (fix if trivial, skip if not)
+   - P3 findings for implementation (these are real findings that should be fixed)
    - The same conventions and project context as Phase 2
 
 2. After fixes are applied, dispatch the **quality sub-agent** (model: sonnet) again
    to verify fmt/clippy/tests still pass.
 
-3. Run `/code-review branch` again. The review skill will independently verify the
-   original findings are resolved and check for new issues introduced by the fixes.
+3. Run `/code-review branch --since <last-reviewed-commit>` to use incremental review
+   mode. This scopes the review to only the fix commits, verifies prior findings are
+   resolved, and checks for new issues — without re-reviewing unchanged code.
+   Record the HEAD commit SHA before each review round so you can pass it as `--since`
+   to the next round.
 
 4. **Loop**: if the re-review produces new P1 or P2 findings, repeat from step 1.
    Present each iteration's findings to the user.
@@ -204,7 +227,7 @@ present the remaining findings to the user. Something structural needs human jud
 
 ## Phase 5: Land
 
-After all phases pass (review is clean or user accepts remaining P3s):
+After all phases pass (review is clean):
 
 ### 5a. Summary
 1. Summarize what was done (1-3 bullet points)

--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -37,6 +37,22 @@ You are the orchestrator. Your job:
 You do NOT: read implementation files into your own context, write code directly,
 or run tests yourself. Sub-agents do the focused work.
 
+## Phase 0: Frame the work
+
+Before planning begins, establish the "so what?" — why does this work matter?
+
+- **Who benefits** from this change?
+- **What's the counterfactual** — what happens if we don't do it?
+- **What does success look like** and how would we know?
+
+For small, well-scoped tasks (bug fix with a clear issue, config change), this can be a
+one-sentence acknowledgment. For larger work — new features, architectural changes, greenfield
+components — this is a deliberate pause to align on intent before investing in a plan.
+
+State the framing to the user. If the "so what?" isn't clear from the task description, ask.
+This framing anchors everything downstream — the plan, the implementation decisions, and the
+flight log entry at the end.
+
 ## Phase 1: Plan
 
 Dispatch a **planning sub-agent** (model: opus) to:

--- a/develop/references/implementation-guide.md
+++ b/develop/references/implementation-guide.md
@@ -7,10 +7,13 @@ You are an implementation agent. You receive a plan and write the code.
 - Follow the plan. If your engineering judgment says the plan is wrong, implement the
   better approach AND document why you diverged.
 - Write or update tests alongside every behavioral change.
-- **Verify the build compiles** before reporting back. Run `cargo check` (Rust) or the
-  equivalent for the project language. If it doesn't compile, fix it. Do not hand off
-  broken builds — compilation is the implementation agent's responsibility.
-- Do NOT run tests, lint, or format — the quality agent handles that.
+- **Verify the build compiles AND passes lint** before reporting back. Run
+  `cargo fmt -- --check && cargo clippy -- -D warnings && cargo check` (Rust) or the
+  equivalent for the project language. If formatting fails, run `cargo fmt` to fix it.
+  If clippy fails, fix the warnings. If it doesn't compile, fix it. Do not hand off
+  broken, unformatted, or lint-failing builds — this is the implementation agent's
+  responsibility.
+- Do NOT run tests — the quality agent handles that.
 - Do NOT commit — the coordinator handles that.
 
 ## How to work
@@ -76,6 +79,39 @@ review cycles — each one caused P1 or P2 findings that required fix-and-re-rev
    and/or cap.
    *Check:* for each long-lived resource created, trace what removes it. If nothing does,
    that's a memory leak. If it's externally triggered with no bound, that's a DoS vector.
+
+9. **Credential wrapping depth** — All tokens and secrets must be `Secret<String>` (or
+   `SecretString` from the `secrecy` crate) from the point of receipt. Never unwrap
+   except at the consumption boundary (HTTP header, keyring API, file write). If a
+   function accepts or returns a token, it uses `Secret<T>`, period. Raw `String` for
+   tokens at any intermediate point is a P1 finding.
+   *Check:* trace every token from its source (env var, keyring, OAuth response, file read)
+   to every consumer. If it's ever a bare `String` between those points, wrap it.
+
+10. **API surface minimization** — Every `pub` item is a semver commitment. Use `pub(crate)`
+    by default; promote to `pub` only when external consumers need it. Public enums and
+    structs with fields get `#[non_exhaustive]`. Prefer public constructors over public
+    fields. Before adding `pub`, ask: "will a consumer outside this crate need this?"
+    *Check:* for each new `pub` item, verify it's needed by external code. For public enums
+    and structs, verify `#[non_exhaustive]` is present. Run `cargo semver-checks` mentally
+    against the previous release.
+
+11. **Behavioral inventory (migrations only)** — When replacing a dependency or rewriting a
+    module, enumerate every behavior the old code provides before writing the replacement:
+    error handling, resource limits (batch sizes, connection caps), caching, implicit
+    configuration (env vars, default paths), internal batching/chunking. Write a test for
+    each behavior before implementing the replacement. See
+    [references/migration-checklist.md](references/migration-checklist.md) for the full checklist.
+    *Check:* for each old behavior identified, confirm there's a test that would fail if
+    the new code omits it.
+
+12. **Design decisions up front** — Before implementing a feature gate, migration shim, or
+    backwards-compat layer, stop and ask: is the simpler design correct? "Just make it
+    public," "just delete the old code," or "just change the API" is often the right answer.
+    Don't implement complexity you'll retract in the next commit.
+    *Check:* if you're about to add a `#[cfg(feature = "...")]` gate or a migration path,
+    write down the simplest alternative that doesn't need it. If that alternative works,
+    use it instead.
 
 ## Sub-agent prompt template
 

--- a/develop/references/migration-checklist.md
+++ b/develop/references/migration-checklist.md
@@ -1,0 +1,74 @@
+# Migration Checklist: Replacing Dependency X with Y
+
+Use this checklist when replacing a dependency, rewriting a module, or swapping out an
+implementation backend. The #1 source of multi-round reviews on migration PRs is implicit
+behaviors in the old code that the new code silently drops.
+
+## Before writing any replacement code
+
+### 1. Behavioral inventory
+
+For the old dependency/module, enumerate every behavior it provides. Check each category:
+
+- [ ] **Error handling** — What errors does X produce? How does it handle invalid input?
+      Does it panic, return Result, or silently succeed? Does Y handle the same cases?
+- [ ] **Resource limits** — Does X have internal batch sizes, connection pools, queue depths,
+      memory caps, or timeout defaults? These are often undocumented. Read the source.
+- [ ] **Caching** — Does X cache results, models, connections, or computed values? Where?
+      (Disk path, env var, in-memory?) Does the cache location change with Y?
+- [ ] **Configuration** — What env vars, config files, or CLI flags does X read? Does Y use
+      different ones? Will users' existing configuration silently stop working?
+- [ ] **Internal chunking/batching** — Does X process inputs in chunks (e.g., batch size 256
+      for embeddings, 1000-row INSERT batches)? If Y doesn't chunk, large inputs may OOM.
+- [ ] **Thread safety** — Is X thread-safe? Is Y? If X was `Send + Sync` and Y isn't, callers
+      sharing it across threads will break.
+- [ ] **Panic safety** — Does X catch panics internally? If Y can panic (e.g., in unsafe code
+      or via `unwrap`), a long-running server with `Mutex`-wrapped state will poison on panic
+      and reject all future requests. Add `catch_unwind` if needed.
+- [ ] **Implicit normalization** — Does X normalize inputs (trim whitespace, lowercase, pad,
+      truncate)? If Y doesn't, outputs may differ subtly.
+
+### 2. Write tests for each behavior
+
+For each behavior identified above, write a test that:
+- Exercises the behavior through the **public API** (not by reimplementing internals)
+- Would **fail** if the new code omits that behavior
+- Documents what it's testing in the test name: `test_<behavior>_preserved_after_migration`
+
+### 3. Check configuration continuity
+
+- [ ] List all env vars the old code reads → verify the new code reads the same ones (or
+      documents the change in migration notes)
+- [ ] Check Dockerfile / CI / deployment configs that reference old paths, model names, or
+      cache directories
+- [ ] Verify any user-facing CLI flags still work or are explicitly removed with a clear error
+
+## During implementation
+
+### 4. Implement with tests green
+
+- Write the replacement, running the behavioral tests from step 2 as you go
+- When a test fails, that's a behavior gap — fix it before moving on
+- Don't delete the old code until all behavioral tests pass with the new code
+
+### 5. Check for dropped safety nets
+
+Ask explicitly:
+- "What happens if the input is 10x larger than any test case?" (batch size, memory)
+- "What happens if the operation panics?" (mutex poisoning, partial state)
+- "What happens if the config env var isn't set?" (different defaults)
+
+## After implementation
+
+### 6. Integration test the full pipeline
+
+- Don't just unit-test the new component in isolation
+- Test the full flow that uses it: input → processing → output
+- Compare outputs against the old implementation for representative inputs
+
+### 7. Update deployment artifacts
+
+- [ ] Dockerfile (cache paths, env vars, model downloads)
+- [ ] CI config (new dependencies, build flags, test commands)
+- [ ] Deployment manifests (resource limits, env vars, volume mounts)
+- [ ] Documentation (README, ADRs, inline comments referencing old dependency)

--- a/develop/references/rust.md
+++ b/develop/references/rust.md
@@ -17,6 +17,18 @@ memory-mcp memory (scope: global) + user workflow preferences.
 7. Macros that hide logic — keep logic visible and debuggable
 8. Ignoring lifetime annotations — but don't add them where not needed
 9. Premature optimization — correctness first
+10. Raw `String` for tokens/secrets — use `secrecy::SecretString` from point of receipt to
+    consumption boundary. Unwrap only where the raw value is needed (HTTP header, keyring,
+    file write). See implementation-guide.md item 8.
+11. Feature gates for things that should just be `pub` — if the only consumer is tests,
+    ask whether the item should simply be public. Don't implement `#[cfg(feature = "testing")]`
+    if `pub` is the right answer.
+12. Vacuous test assertions — a test should fail if its assertion is removed. Tests that
+    compare single-element collections, assert `true`, or duplicate internal logic instead
+    of using the library's public API prove nothing.
+13. Missing `#[non_exhaustive]` on public enums and structs with fields — this is required
+    for semver safety. Adding a variant or field to a non-exhaustive type is not a breaking
+    change; adding it to a bare `pub enum` is.
 
 ## Positive patterns
 

--- a/land/SKILL.md
+++ b/land/SKILL.md
@@ -38,8 +38,13 @@ Use memory-mcp tools (`edit` / `remember`) for all updates. Run `sync` after.
 For each repo that was touched this session:
 1. `git status` — check for uncommitted changes
 2. `git diff` — review what's staged and unstaged
-3. Commit with a clear message (follow repo conventions)
-4. Push to remote
+3. **Run quality checks before committing** — for Rust projects:
+   `cargo fmt -- --check && cargo clippy -- -D warnings && cargo nextest run --workspace`
+   If any check fails, fix the issue before committing. Do not push code that hasn't
+   passed the same gates CI will check. For other languages, run the equivalent
+   formatter, linter, and test suite.
+4. Commit with a clear message (follow repo conventions)
+5. Push to remote
 
 Skip repos with clean working trees.
 

--- a/land/SKILL.md
+++ b/land/SKILL.md
@@ -110,6 +110,11 @@ Write the day's wins entry in `butterflyskies/flight-log`:
 
 If the entry already exists, append new items — don't rewrite what's there.
 
+If a "so what?" framing was established at the start of the session (e.g. via `/develop`
+Phase 0), write the entry against that intent — confirm what was achieved relative to
+the original motivation, not just list what was done. The framing makes entries meaningful
+when read back later.
+
 The tone should be celebratory and specific — what was built, what was fixed, what was
 figured out. Not a dry changelog; a record of progress that's satisfying to read back.
 


### PR DESCRIPTION
## Summary

Two rounds of skill evolution:

### Workflow optimization (reduce code review rounds)
Systematic improvements derived from analysis of 50 merged PRs in memory-mcp. The 4 PRs with substantive review feedback averaged 4+ rounds each — these changes target the root causes.

- Implementation agent now runs fmt+clippy before handoff (eliminates ~1 guaranteed round per PR)
- Pre-flight checklist expanded: credential wrapping depth, API surface minimization, behavioral inventory for migrations, design decisions up front
- New `migration-checklist.md` reference for dependency replacement tasks
- Code review sub-agents: competitive framing replaced with precision framing; test quality dimension added to sub-agent B
- Incremental review mode (`--since`) for fix-round efficiency
- `/land` skill runs quality checks before committing
- Phase 4.5 fix agent receives original plan + ADRs for context
- P3 findings are addressed, not skipped (priority signal, not skip)
- Diff-size gate warns at >500 LOC and proposes splits
- Rust anti-patterns expanded: raw String tokens, unnecessary feature gates, vacuous tests, missing `#[non_exhaustive]`

### Design methodology integration
Evolves the skill set based on a structured development methodology document covering security-first greenfield development, threat modeling, and requirements traceability.

- **New `/design` skill** — structured pre-implementation design process producing specification artifacts in `docs/design/`. Phases: problem space, concept (use cases/abuse cases/requirements/SRTM), architecture (Mermaid diagrams), gated STRIDE threat modeling, and test plan derivation. Scales from lightweight to full ceremony via Phase 0 calibration. Includes distributed effectiveness tracking across the skill system.
- **`/develop` Phase 0** — "Frame the work" adds a "so what?" prompt before planning: who benefits, what's the counterfactual, what does success look like.
- **`/land` Phase 7** — flight log entries now anchor against the "so what?" framing established at session start.

## Test plan
- [ ] Invoke `/design` on a real or hypothetical task, walk through Phase 0 calibration
- [ ] Verify artifact output format in `docs/design/`
- [ ] Confirm human gates pause for approval at each phase boundary
- [ ] Confirm Phase 4 threat modeling gate presents options without defaulting
- [ ] Verify `/develop` Phase 0 prompts for framing before planning
- [ ] Verify `/land` flight log references established framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)