### PR TITLE
chore: specify opus 4.6 model version in sub-agent references

### DIFF
--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -76,7 +76,7 @@ each with `run_in_background: true`. This ensures true concurrent execution — 
 them sequentially wastes time and defeats the purpose of independent analysis. Each agent
 gets the same diff and context but a different analytical lens. The separation ensures
 independent findings — a bug one agent normalizes, another catches. Use **sonnet** for
-sub-agents A and B (mechanical analysis), **opus** for sub-agent C (judgment-heavy
+sub-agents A and B (mechanical analysis), **opus** (4.6) for sub-agent C (judgment-heavy
 architectural review).
 
 ### Sub-agent A: Correctness & Safety
@@ -171,7 +171,7 @@ For each finding, output EXACTLY this format:
 - Fix: <concrete code change or approach>
 ```
 
-### Sub-agent C: Architecture & Security (model: opus)
+### Sub-agent C: Architecture & Security (model: opus 4.6)
 
 ```
 You are reviewing code changes for architectural fitness and security. You did NOT

--- a/design/SKILL.md
+++ b/design/SKILL.md
@@ -287,7 +287,7 @@ this in the discussion — it's a data point, not a mandate.
 
 ### If proceeding (option 1 or 2):
 
-Dispatch a **threat modeling sub-agent** (model: opus) to analyze the architecture.
+Dispatch a **threat modeling sub-agent** (model: opus 4.6) to analyze the architecture.
 
 **Sub-agent prompt template:**
 ```
@@ -502,7 +502,7 @@ process may be over-specified for typical task size.
 | Sub-agent | Model | Rationale |
 |-----------|-------|-----------|
 | Architecture diagrams (Phase 3b) | **sonnet** | Mechanical generation from agreed decisions |
-| Threat modeling (Phase 4) | **opus** | Judgment-heavy — must distinguish real threats from noise |
+| Threat modeling (Phase 4) | **opus** (4.6) | Judgment-heavy — must distinguish real threats from noise |
 
 Phases 0, 1, 2, and 5 are coordinator-led (collaborative with the user). The
 coordinator inherits the session model. No sub-agents needed — the value is in the

--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -55,7 +55,7 @@ flight log entry at the end.
 
 ## Phase 1: Plan
 
-Dispatch a **planning sub-agent** (model: opus) to:
+Dispatch a **planning sub-agent** (model: opus 4.6) to:
 
 1. If `$ARGUMENTS` references an issue, fetch it: `gh issue view <N> --json title,body,comments`
 2. Read the relevant code using Serena's symbolic tools — `get_symbols_overview` for structure,
@@ -298,10 +298,10 @@ Pass the language-specific reference to sub-agents that need it.
 
 | Sub-agent | Model | Rationale |
 |-----------|-------|-----------|
-| Planning | **opus** | Resolves ambiguity, weighs tradeoffs, asks the right questions |
+| Planning | **opus** (4.6) | Resolves ambiguity, weighs tradeoffs, asks the right questions |
 | Implementation | **sonnet** | Concrete execution from a well-defined plan |
 | Quality | **sonnet** | Mechanical verification — run tools, fix what fails |
-| Architectural review | **opus** | Judgment-heavy — completeness gaps, subtle contract breaks, "this will hurt later" |
+| Architectural review | **opus** (4.6) | Judgment-heavy — completeness gaps, subtle contract breaks, "this will hurt later" |
 
 The coordinator inherits the user's session model (typically opus). Use the `model` parameter
 on the Agent tool to set each sub-agent's model explicitly.


### PR DESCRIPTION
## Summary
- Pin sub-agent model references to "opus 4.6" / "opus (4.6)" across code-review, design, and develop skills
- Prevents ambiguity as new opus versions ship — skills explicitly target the version they were tested with

## Changed files
- `code-review/SKILL.md` — sub-agent C model reference
- `design/SKILL.md` — threat modeling sub-agent model reference + model selection table
- `develop/SKILL.md` — planning and architectural review sub-agent model references + model selection table

🤖 Generated with [Claude Code](https://claude.com/claude-code)