### PR TITLE
develop: add self-critique step to Phase 1 planning

### DIFF
--- a/develop/SKILL.md
+++ b/develop/SKILL.md
@@ -74,12 +74,23 @@ Output format:
 ## Risks
 - [risk description and mitigation]
 
+## Self-critique
+Before finalizing, ask yourself: "What did I miss? What assumptions am I making?
+What edge cases aren't covered? What could go wrong?"
+- [A few bullet points of honest self-assessment — gaps, shaky assumptions,
+  things that might bite us during implementation]
+
 ## Questions (if any)
 - [question for the user]
 ```
 
-Present the plan to the user. **Always wait for explicit approval before proceeding
-to Phase 1.5.** Do not auto-proceed — the user reviews and greenlights every plan.
+The self-critique section helps catch gaps before the user has to find them. It should
+be lightweight — a few bullet points, not a second planning pass. The planning agent
+should genuinely challenge its own plan, not rubber-stamp it.
+
+Present the plan (including self-critique) to the user. **Always wait for explicit
+approval before proceeding to Phase 1.5.** Do not auto-proceed — the user reviews
+and greenlights every plan.
 
 ## Phase 1.5: Record decisions (ADRs)
 


### PR DESCRIPTION
## Summary
- Adds a **Self-critique** section to the Phase 1 planning sub-agent's output template
- After producing a plan, the agent asks itself: "What did I miss? What assumptions am I making? What edge cases aren't covered? What could go wrong?"
- The self-critique is presented to the user alongside the plan, catching gaps before the user has to find them
- Lightweight by design — a few bullet points of honest self-assessment, not a second planning pass

## Motivation
Inspired by spec-driven development practices. Self-critique before external review reduces iteration cycles and surfaces blind spots the planning agent may have.

## Test plan
- [ ] Run `/develop plan <task>` and verify the planning sub-agent includes a Self-critique section in its output
- [ ] Confirm the self-critique contains genuine gap analysis, not rubber-stamp approval
- [ ] Verify the plan is still presented for user approval before proceeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)